### PR TITLE
Tentatively using some @flow

### DIFF
--- a/build/tasks/flow.js
+++ b/build/tasks/flow.js
@@ -1,15 +1,37 @@
+// @flow
 import reporter from 'flow-reporter'
 import {TaskHandler} from '../../packages/gulpy-boiler-utils'
 
+import type {
+  Gulp,
+  ConfigObject,
+  PluginObject
+} from '../types'
+
 export default class Flow extends TaskHandler {
-  task(gulp, plugins, config) {
+  task(
+    gulp: Gulp,
+    plugins: PluginObject,
+    config: ConfigObject,
+  ) {
+    // If TaskHandler defaulted to having these keys present instead of empty,
+    // we could move faster instead of checking for presence.
+    let addbase, src
+
     const {utils} = config
-    const {addbase} = utils
     const {flowtype} = plugins
-    const src = [
-      addbase('build', '**/*.js'),
-      addbase('packages', '*', 'src/**/*.js')
-    ]
+
+    if (utils) {
+      addbase = utils.addbase
+    }
+
+    if (addbase) {
+      src = [
+        addbase('build', '**/*.js'),
+        addbase('packages', '*', 'src/**/*.js')
+      ]
+    }
+
     const options = {
       all: false,
       weak: false,

--- a/build/types.js
+++ b/build/types.js
@@ -1,0 +1,39 @@
+// @flow
+
+// A mostly pain-free way to integrate node_modules into your flow
+// Warning, node_modules has plenty of dragons for flow...
+export type {Gulp} from 'gulp'
+
+// Not sure what goes in this, seems like name of plugin and functions or
+// objects... I'm leaving it as just Object, which is usually frowned upon
+// because pretty much everything is Object.
+export type PluginObject = Object
+
+// Based on what I see going in...
+// Note that all keys are optional since TaskHandler can default this to being
+// an empty object. If this automatically gets extended with default config
+// options, that needs to happen in TaskHandler#constructor for happy flow
+export type ConfigObject = {
+  environment?: {
+    assetPath: string,
+    env: 'development' | 'test' |'production',
+    isCi: boolean,
+    isDev: boolean,
+    isLocalDev: boolean,
+  },
+  metadata?: {
+    name: string,
+  },
+  sources?: {
+    buildDir: string,
+    devPath: string,
+    devPort: number,
+    protocol: string,
+    srcDir: string,
+  },
+  utils?: {
+    addbase: Function,
+    addroot: Function,
+    addTarget: Function,
+  },
+}

--- a/packages/gulpy-boiler-utils/src/TaskHandler.js
+++ b/packages/gulpy-boiler-utils/src/TaskHandler.js
@@ -1,17 +1,34 @@
+// @flow
 import EventEmitter from 'events'
 import load from 'gulpy-boiler-load-plugins'
 import merge from 'merge-deep'
 import cli from './cli'
 
+import type {
+  Gulp,
+  ConfigObject,
+  PluginObject
+} from '../../../build/types'
+
 export default class TaskHandler extends EventEmitter {
-  constructor(name, plugins = {}, config = {}) {
+  name: string;
+  plugins: PluginObject;
+  config: ConfigObject;
+
+  constructor(
+    name: string,
+    plugins: PluginObject = {},
+    config: ConfigObject = {}
+  ) {
     super()
     this.name = name
     this.plugins = plugins
     this.config = config
   }
 
-  cli(opts = {}) {
+  // In a better world, we'd know what options can be passed in, and I'd know
+  // what exactly is inside the array being returned
+  cli(opts: Object = {}) : Array<any> {
     const data = cli(opts)
     const {flags} = data
     const cliData = Object.keys(flags).reduce((acc, key) => {
@@ -38,25 +55,26 @@ export default class TaskHandler extends EventEmitter {
    *  - config/plugins external task
    *  - onto context of TaskHandler parent instance
    */
-  configure(config = {}) {
+  configure(config: ConfigObject = {}): ConfigObject {
     this.config = merge({}, this.config, config)
 
     return this.config
   }
 
-  loadPlugins(opts = {}) {
+  loadPlugins(opts: PluginObject = {}): PluginObject {
     Object.assign(this.plugins, load(opts))
 
     return this.plugins
   }
 
-  on(event, cb) {
-    super.on(event, cb)
-
-    return this
+  run(gulp: Gulp, ...args: Array<any>): void {
+    return this.task(gulp, this.plugins, this.config, ...args)
   }
 
-  run(gulp, ...args) {
-    return this.task(gulp, this.plugins, this.config, ...args)
+  task(
+    gulp: Gulp,
+    plugins: PluginObject,
+    config: ConfigObject,
+  ): void {
   }
 }


### PR DESCRIPTION
This adds @flow usage to TaskHandler, the Flow task, and a new types
file which might eventually encapsulate some commonly used types within
the build system.

Some random notes:
- I really doubt build/tasks is the appropriate place for it
- I commented about this, but the Flow class now needs to null-check
  utils and addbase, because by default they could be empty (according
  to the current definition, since TaskHandler can default both
  objects to be empty). In a happier world, they'd all get some
  trusted defaults and some optional values, and flow would enforce.
- I added TaskManager.prototype.task() because it's being invoked from
  run(), but not defined on the top prototype.
- I removed TaskManager.prototype.on() because it seemed pretty
  redundant and flow decided that it wasn't compatible with
  EventEmitter. This might be related to a bug [1] that got fixed a
  few weeks ago, or it might be because EventEmitter.prototype.on is
  actually assigned to EventEmitter.prototype.addListener, which flow
  might consider somewhat untrustworthy. My guess is it's the bug.
- No semi colons is crazy town!

[1] https://github.com/facebook/flow/commit/b11bbbc3441b5860e99d7eb6504b6197f14caa7d
